### PR TITLE
Add admin mode: teacher basic auth and teachers.json

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -48,3 +48,23 @@ The application uses a simple data model with meaningful identifiers:
    - Grade level
 
 All data is stored in memory, which means data will be reset when the server restarts.
+
+## Admin Mode (teacher-only registration)
+
+This project supports a simple "admin mode" where teachers can register and
+unregister students. For now this uses HTTP Basic auth with credentials stored
+in `src/teachers.json`.
+
+To use admin endpoints:
+
+1. Edit `src/teachers.json` and add teacher credentials (username/password).
+2. Use HTTP Basic auth when calling the signup or unregister endpoints. For
+   example, with curl:
+
+```bash
+curl -u teacher:password123 -X POST "http://localhost:8000/activities/Chess%20Club/signup?email=student@mergington.edu"
+```
+
+Note: This is a simple development convenience. For production, replace this
+with a proper authentication system and hashed passwords.
+

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,6 @@
+[
+  {
+    "username": "teacher",
+    "password": "password123"
+  }
+]


### PR DESCRIPTION
This PR implements a simple Admin Mode for the Mergington High School API.

Changes:
- Add `src/teachers.json` (sample teacher credentials)
- Add `verify_teacher` HTTP Basic auth helper in `src/app.py`
- Protect `POST /activities/{activity_name}/signup` and `DELETE /activities/{activity_name}/unregister` endpoints so only teachers can perform them
- Update `src/README.md` with usage instructions for admin endpoints

Notes:
- This uses plaintext passwords in `src/teachers.json` for simplicity as discussed in the issue; please replace with a secure store and hashed passwords for production.
- I kept the existing endpoints and data model unchanged except for auth checks.

If you'd like, I can also implement a fallback that allows student self-signup behind a flag, or wire a small admin UI.